### PR TITLE
fix(deps): bump form-data to 2.5.6 to fix CRLF injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "electron-squirrel-startup": "^1.0.1",
         "esbuild": "^0.28.2",
         "http-proxy-middleware": "^4.2.0",
-        "serve": "*",
+        "serve": "latest",
         "tslint": "^6.1.3",
         "typescript": "^6.0.3"
       }
@@ -4812,15 +4812,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -5215,9 +5215,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
+    "form-data": "^2.5.6",
     "tar": "^7.5.19",
     "tmp": "^0.2.6",
     "js-yaml": "^4.3.0",


### PR DESCRIPTION
Closes #932

## Problem

`form-data` before 2.5.6 concatenates multipart field names and filenames into the `Content-Disposition` header without escaping CR, LF, or `"`, allowing header injection.

- Advisory: [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) (CWE-93, CVSS 7.5, high)
- Affected range: `<2.5.6`, lockfile had `2.5.5`

The dependency is transitive and lives on the production side:

```
cycle-flyer -> @cycle/http@15.4.0 -> superagent@3.8.3 -> form-data@2.5.5
```

`superagent@3.8.3` is deprecated and is not going to move off `form-data@^2.3.1`, so the version is forced via `overrides`.

## Impact on this app

Low. There is no `FormData` / `.field()` / `.attach()` / multipart usage anywhere in `src/` or `srcElectron/` — requests to the bitFlyer API are JSON only, so `form-data` is never on the executed path. The bump is to clear the advisory rather than to close an exploitable hole here.

## Verification

- `npm ls form-data` resolves to `2.5.6`
- `npm audit` no longer reports `form-data` (high count 21 -> 20)
- `npm run lint` passes
- `npm run build` passes

## Note

The lockfile diff also contains an incidental `"serve": "*"` -> `"serve": "latest"` normalization in the root `packages` block, and a `hasown` bump to `2.0.4` required by `form-data@2.5.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)